### PR TITLE
Fix enter behavior when the next list item is done

### DIFF
--- a/app/src/main/java/com/omgodse/notally/activities/MakeList.kt
+++ b/app/src/main/java/com/omgodse/notally/activities/MakeList.kt
@@ -87,13 +87,12 @@ class MakeList : NotallyActivity() {
     }
 
 
-    private fun addListItem() {
+    private fun addListItem(position: Int = adapter.items.size) {
         val listItem = ListItem(String(), false)
-        adapter.items.add(listItem)
-        val position = adapter.items.size
+        adapter.items.add(position, listItem)
         adapter.notifyItemInserted(position)
         binding.RecyclerView.post {
-            val viewHolder = binding.RecyclerView.findViewHolderForAdapterPosition(position - 1) as MakeListViewHolder?
+            val viewHolder = binding.RecyclerView.findViewHolderForAdapterPosition(position) as MakeListViewHolder?
             viewHolder?.requestFocus()
         }
     }
@@ -148,8 +147,8 @@ class MakeList : NotallyActivity() {
 
     private fun moveToNext(position: Int) {
         val viewHolder = binding.RecyclerView.findViewHolderForAdapterPosition(position + 1) as MakeListViewHolder?
-        if (viewHolder != null) {
+        if (viewHolder != null && !viewHolder.binding.CheckBox.isChecked) {
             viewHolder.requestFocus()
-        } else addListItem()
+        } else addListItem(position + 1)
     }
 }

--- a/app/src/main/java/com/omgodse/notally/recyclerview/viewholders/MakeListViewHolder.kt
+++ b/app/src/main/java/com/omgodse/notally/recyclerview/viewholders/MakeListViewHolder.kt
@@ -10,7 +10,7 @@ import com.omgodse.notally.recyclerview.ListItemListener
 import com.omgodse.notally.miscellaneous.setOnNextAction
 import com.omgodse.notally.xml.ListItem
 
-class MakeListViewHolder(private val binding: ListItemBinding, listItemListener: ListItemListener?) :
+class MakeListViewHolder(val binding: ListItemBinding, listItemListener: ListItemListener?) :
     RecyclerView.ViewHolder(binding.root) {
 
     init {


### PR DESCRIPTION
Previously, if a list item was followed by a done item there was no
way to insert an additional one.

In the long term, I think the current behavior is still clunky and the one
employed by Keep (which moves all done items to a separate section)
is more intuitive (but perhaps best kept under a toggle).