### PR TITLE
Feature: Support for themed/monochrome icon

### DIFF
--- a/app/src/main/res/drawable/notally_monochrome.xml
+++ b/app/src/main/res/drawable/notally_monochrome.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <group>
+    <clip-path
+        android:pathData="M0,0h108v108h-108z"/>
+    <path
+        android:pathData="M76,120.01L108,108L120,76L76,32L76,76L32,76L76,120.01Z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.2"
+        android:fillType="nonZero"
+        android:strokeColor="#00000000"/>
+    <path
+        android:pathData="M32,32L32,76L76,76L76,32L32,32ZM36,40L72,40L72,43L36,43L36,40ZM36,48L72,48L72,51L36,51L36,48ZM36,56L54,56L54,59L36,59L36,56Z"
+        android:fillColor="#000000"
+        android:fillType="nonZero"
+        android:strokeColor="#00000000"/>
+  </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/notally.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/notally.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/LightBlue500" />
     <foreground android:drawable="@drawable/notally_foreground" />
+    <monochrome android:drawable="@drawable/notally_monochrome" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/notally_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/notally_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/LightBlue500" />
     <foreground android:drawable="@drawable/notally_foreground" />
+    <monochrome android:drawable="@drawable/notally_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
Android 13 introduced a new feature called [themed icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive). Themed icons use the wallpaper colors.
Here are screenshots so you can see what the themed icons would look like if a user enables them.
![Screenshot_20230423-210301_Trebuchet](https://user-images.githubusercontent.com/115667885/233860505-6115dd70-a00c-408c-b083-d3a2d0d70fb3.png)
![Screenshot_20230423-210238_Trebuchet](https://user-images.githubusercontent.com/115667885/233860512-805f5fa5-2b52-4864-865c-b39ec7b9b27c.png)
