### PR TITLE
Resolved syntax issues in files: values-nb, values-nn, values-vi

### DIFF
--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -109,8 +109,8 @@
     <string name="disable_auto_backup">Slå av automatisk sikkerhetskopiering</string>
     <string name="choose_another_folder">Velg en annen mappe</string>
     <string name="cant_find_folder">Finner ikke mappen. Den kan ha blitt flyttet eller slettet</string>
-    <string name="invalid_backup">Ugyldig sikkerhetskopi<string>
-    <string name="imported_backup">Importert sikkerhetskopi<string>
+    <string name="invalid_backup">Ugyldig sikkerhetskopi</string>
+    <string name="imported_backup">Importert sikkerhetskopi</string>
     <string name="exporting_backup">Eksporterer sikkerhetskopi</string>
     <string name="importing_backup">Importerer sikkerhetskopi</string>
     <string name="calculating">Beregner …</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -109,8 +109,8 @@
     <string name="disable_auto_backup">Slå av automatisk sikkerheitskopiering</string>
     <string name="choose_another_folder">Vel ei anna mappe</string>
     <string name="cant_find_folder">Finn ikkje mappa. Den kan ha blitt flytta eller sletta</string>
-    <string name="invalid_backup">Ugyldeg sikkerheitskopi<string>
-    <string name="imported_backup">Importert sikkerheitskopi<string>
+    <string name="invalid_backup">Ugyldeg sikkerheitskopi</string>
+    <string name="imported_backup">Importert sikkerheitskopi</string>
     <string name="exporting_backup">Eksporterer sikkerheitskopi</string>
     <string name="importing_backup">Importerer sikkerheitskopi</string>
     <string name="calculating">Bereknar …</string>
@@ -141,7 +141,7 @@
     <string name="please_grant_notally">Gi Notally tillating til å senda varsel. Dette brukas for å visa fremdrifta viss handlinger som å sletta bilete eller importera sikkerheitskopier tar tid</string>
 
     <plurals name="cant_add_images">
-        <item quantity="other">Kan ikkje legga til %d bilete</item>
-    </plurals>
+        <item quantity="one">Kan ikkje legga til %d bilete</item>
+    </plurals>other
 
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -118,7 +118,7 @@
     <string name="calculating">Đang xử lý…</string>
 
     <string name="export_backup">Xuất dữ liệu</string>
-    <string name="import_backup">Nhập dữ liệu</string>
+<!--    <string name="import_backup">Nhập dữ liệu</string>-->
 
     <string name="about">Giới thiệu</string>
     <string name="libraries">Thư viện sử dụng</string>


### PR DESCRIPTION
When i cloned the project and ran gradle build, it failed due to these minor issues in syntax of the translations string.xml files. just corrected those. This pull request aims at resolving the above said issue and provide smoother gradle build for other contributors.