### PR TITLE
start searching  with one click

### DIFF
--- a/app/src/main/java/com/omgodse/notally/activities/MainActivity.kt
+++ b/app/src/main/java/com/omgodse/notally/activities/MainActivity.kt
@@ -391,7 +391,16 @@ class MainActivity : AppCompatActivity() {
             binding.MakeList.hide()
         }
 
-        binding.EnterSearchKeyword.isVisible = (destination.id == R.id.Search)
+        val isVisible = destination.id == R.id.Search
+        binding.EnterSearchKeyword.isVisible = isVisible
+        val imm: InputMethodManager =
+            getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager;
+        if (isVisible) {
+            binding.EnterSearchKeyword.requestFocus();
+            imm.showSoftInput(binding.EnterSearchKeyword, InputMethodManager.SHOW_IMPLICIT);
+        } else {
+            imm.hideSoftInputFromWindow(binding.EnterSearchKeyword.windowToken, 0);
+        }
     }
 
     private fun navigateWithAnimation(id: Int) {


### PR DESCRIPTION
Hi, Om, thank you very much for this clean and beautiful notes app, I'm using it for years.

Here, I would like suggest to shorten the path for searching intention. Currently, it takes 2 steps before any searching input, ie. click search button and then touch the search field. With this pull request, the searching could be done with one click, and then the input shows up.