### PR TITLE
A gist showing you you how to get/export your raw (text) notes out of notally’s .sqlite-only backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Notally was created because I wanted to make something that was beautiful and at
 ### Features
 * Widgets
 * Auto backup
-* Adjustable text size
+* Adjustable text size 
 * Support for Lollipop devices and up
 * APK size of 1.4 MB (1.8 MB uncompressed)
 * Color, pin and label your notes for quick organisation


### PR DESCRIPTION
Pull the individual raw text notes out of the `.sqlite` backup / export, so that you don't have to manually copy and paste every single note out:
- https://gist.github.com/fxkrait/7dc5d7608d5e727d9f43d06855d7b7d1