### PR TITLE
Reminder improvements

### DIFF
--- a/app/src/main/java/com/omgodse/notally/activities/ConfigureWidget.kt
+++ b/app/src/main/java/com/omgodse/notally/activities/ConfigureWidget.kt
@@ -50,10 +50,9 @@ class ConfigureWidget : AppCompatActivity(), ItemListener {
         val textSize = preferences.textSize.value
         val dateFormat = preferences.dateFormat.value
         val fullFormat = DateFormat.getDateInstance(DateFormat.FULL)
-        val shortFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
         val mediaRoot = IO.getExternalImagesDirectory(application)
 
-        adapter = BaseNoteAdapter(Collections.emptySet(), dateFormat, textSize, maxItems, maxLines, maxTitle, fullFormat, shortFormat, mediaRoot, this)
+        adapter = BaseNoteAdapter(Collections.emptySet(), dateFormat, textSize, maxItems, maxLines, maxTitle, fullFormat, mediaRoot, this)
 
         binding.RecyclerView.adapter = adapter
         binding.RecyclerView.setHasFixedSize(true)

--- a/app/src/main/java/com/omgodse/notally/activities/NotallyActivity.kt
+++ b/app/src/main/java/com/omgodse/notally/activities/NotallyActivity.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.text.Editable
+import android.text.format.DateUtils
 import android.util.TypedValue
 import android.view.MenuItem
 import android.view.View
@@ -425,10 +426,11 @@ abstract class NotallyActivity(private val type: Type) : AppCompatActivity() {
 
     private fun setupReminder() {
         val padding = (resources.displayMetrics.density * 16).toInt()
-        val formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
+
         model.reminder.observe(this) { reminder ->
             if (reminder != null) {
-                val date = formatter.format(reminder.timestamp)
+                val dateFormat = Operations.getReminderDateFormat(reminder.timestamp)
+                val date = DateUtils.formatDateTime(binding.root.context, reminder.timestamp, dateFormat)
                 binding.Reminder.text = when (reminder.frequency) {
                     Frequency.ONCE -> date
                     Frequency.DAILY -> getString(R.string.repeats_daily, date)

--- a/app/src/main/java/com/omgodse/notally/activities/NotallyActivity.kt
+++ b/app/src/main/java/com/omgodse/notally/activities/NotallyActivity.kt
@@ -499,7 +499,8 @@ abstract class NotallyActivity(private val type: Type) : AppCompatActivity() {
             val calendar = Calendar.getInstance()
             val hour = calendar.get(Calendar.HOUR_OF_DAY)
             val minute = calendar.get(Calendar.MINUTE)
-            TimePickerDialog(this, timeListener, hour, minute, false).show()
+            val is24HourView = android.text.format.DateFormat.is24HourFormat(applicationContext);
+            TimePickerDialog(this, timeListener, hour, minute, is24HourView).show()
         }
 
         var selectedFrequency = 0

--- a/app/src/main/java/com/omgodse/notally/fragments/NotallyFragment.kt
+++ b/app/src/main/java/com/omgodse/notally/fragments/NotallyFragment.kt
@@ -96,9 +96,8 @@ abstract class NotallyFragment : Fragment(), ItemListener {
         val maxTitle = model.preferences.maxTitle
         val dateFormat = model.preferences.dateFormat.value
         val fullFormat = DateFormat.getDateInstance(DateFormat.FULL)
-        val shortFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
 
-        adapter = BaseNoteAdapter(model.actionMode.selectedIds, dateFormat, textSize, maxItems, maxLines, maxTitle, fullFormat, shortFormat, model.mediaRoot, this)
+        adapter = BaseNoteAdapter(model.actionMode.selectedIds, dateFormat, textSize, maxItems, maxLines, maxTitle, fullFormat, model.mediaRoot, this)
         adapter?.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
 
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {

--- a/app/src/main/java/com/omgodse/notally/miscellaneous/Operations.kt
+++ b/app/src/main/java/com/omgodse/notally/miscellaneous/Operations.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.res.ColorStateList
 import android.net.Uri
 import android.os.Build
+import android.text.format.DateUtils
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -26,6 +27,7 @@ import java.io.FileOutputStream
 import java.io.OutputStreamWriter
 import java.io.PrintWriter
 import java.text.DateFormat
+import java.util.Calendar
 
 object Operations {
 
@@ -104,6 +106,19 @@ object Operations {
         }
     }
 
+    fun getReminderDateFormat(timestamp: Long): Int {
+        var dateFormat = DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_SHOW_TIME or DateUtils.FORMAT_ABBREV_MONTH
+        val future = Calendar.getInstance()
+        val now = Calendar.getInstance()
+
+        // If reminder is not in next year, omit the year display.
+        future.timeInMillis = timestamp
+        if (future.get(Calendar.YEAR) == now.get(Calendar.YEAR)) {
+            dateFormat = dateFormat or DateUtils.FORMAT_NO_YEAR
+        }
+
+        return dateFormat
+    }
 
     fun bindLabels(group: ChipGroup, labels: List<String>, textSize: String) {
         if (labels.isEmpty()) {

--- a/app/src/main/java/com/omgodse/notally/recyclerview/adapter/BaseNoteAdapter.kt
+++ b/app/src/main/java/com/omgodse/notally/recyclerview/adapter/BaseNoteAdapter.kt
@@ -25,7 +25,6 @@ class BaseNoteAdapter(
     private val maxLines: Int,
     private val maxTitle: Int,
     private val fullFormat: DateFormat,
-    private val shortFormat: DateFormat,
     private val mediaRoot: File?,
     private val listener: ItemListener
 ) : ListAdapter<Item, RecyclerView.ViewHolder>(DiffCallback) {
@@ -61,7 +60,7 @@ class BaseNoteAdapter(
             }
             else -> {
                 val binding = RecyclerBaseNoteBinding.inflate(inflater, parent, false)
-                BaseNoteVH(binding, dateFormat, textSize, maxItems, maxLines, maxTitle, listener, prettyTime, fullFormat, shortFormat)
+                BaseNoteVH(binding, dateFormat, textSize, maxItems, maxLines, maxTitle, listener, prettyTime, fullFormat)
             }
         }
     }

--- a/app/src/main/java/com/omgodse/notally/recyclerview/viewholder/BaseNoteVH.kt
+++ b/app/src/main/java/com/omgodse/notally/recyclerview/viewholder/BaseNoteVH.kt
@@ -1,6 +1,7 @@
 package com.omgodse.notally.recyclerview.viewholder
 
 import android.graphics.drawable.Drawable
+import android.text.format.DateUtils
 import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
@@ -32,6 +33,7 @@ import com.omgodse.notally.room.SpanRepresentation
 import com.omgodse.notally.room.Type
 import org.ocpsoft.prettytime.PrettyTime
 import java.io.File
+import java.util.Calendar
 import java.util.Date
 
 class BaseNoteVH(
@@ -43,8 +45,7 @@ class BaseNoteVH(
     maxTitle: Int,
     listener: ItemListener,
     private val prettyTime: PrettyTime,
-    private val fullFormat: java.text.DateFormat,
-    private val shortFormat: java.text.DateFormat
+    private val fullFormat: java.text.DateFormat
 ) : RecyclerView.ViewHolder(binding.root) {
 
     init {
@@ -208,8 +209,9 @@ class BaseNoteVH(
 
     private fun setReminder(reminder: Reminder?) {
         if (reminder != null) {
-            val date = shortFormat.format(reminder.timestamp)
+            val dateFormat = Operations.getReminderDateFormat(reminder.timestamp)
             val context = binding.root.context
+            val date = DateUtils.formatDateTime(context, reminder.timestamp, dateFormat)
             binding.Reminder.text = when (reminder.frequency) {
                 Frequency.ONCE -> date
                 Frequency.DAILY -> context.getString(R.string.repeats_daily, date)


### PR DESCRIPTION
@OmGodse This PR makes 2 changes:

- Sets a shorter date format for reminders. Reasoning is that there is no need to display year if it is the current year.

- Respects 24-hour format in `TimeDialogPicker`