### PR TITLE
fastlane: improve full description and add DE locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Notally was created because I wanted to make something that was beautiful and at
 
 [<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" alt="Get it on Google Play"  height="70"/>](https://play.google.com/store/apps/details?id=com.omgodse.notally)
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="70"/>](https://f-droid.org/packages/com.omgodse.notally/)
+[<img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="Get it on IzzyOnDroid" height="70"/>](https://apt.izzysoft.de/packages/com.omgodse.notally)
 
 ### Translations
 All translations are crowd sourced. To contribute, follow these [guidelines](https://m2.material.io/design/communication/writing.html) and email me or open a pull request.

--- a/fastlane/metadata/android/de/short_description.txt
+++ b/fastlane/metadata/android/de/short_description.txt
@@ -1,0 +1,1 @@
+Eine einfache und elegante Open Source Notes App

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -2,30 +2,30 @@ Notally is a minimalistic note taking app with a beautiful material design and p
 
 <b>Organization</b>
 
-Set reminders to be on track
-Create lists to stay organised
-Pin notes to always keep them at the top
-Color and label your notes for quick organisation
-Archive notes to keep them around, but out of your way
-Complement your notes with pictures (JPG, PNG, WEBP)
-Create rich text notes with support for bold, italics, mono space and strike-through
-Add clickable links to notes with support for phone numbers, email addresses and web urls
+* Set reminders to be on track
+* Create lists to stay organised
+* Pin notes to always keep them at the top
+* Color and label your notes for quick organisation
+* Archive notes to keep them around, but out of your way
+* Complement your notes with pictures (JPG, PNG, WEBP)
+* Create rich text notes with support for bold, italics, mono space and strike-through
+* Add clickable links to notes with support for phone numbers, email addresses and web urls
 
 <b>Export notes in the following formats</b>
 
-• PDF
-• TXT
-• JSON
-• HTML
+* PDF
+* TXT
+* JSON
+* HTML
 
 <b>Convenience</b>
 
-• Dark mode
-• Completely free
-• Adjustable text size
-• Auto save and backup
-• APK size of 1.4 MB (1.8 MB uncompressed)
-• Add notes and lists to your home screen with widgets
+* Dark mode
+* Completely free
+* Adjustable text size
+* Auto save and backup
+* APK size of 1.4 MB (1.8 MB uncompressed)
+* Add notes and lists to your home screen with widgets
 
 <b>Privacy</b>
 
@@ -33,11 +33,11 @@ There are no ads, trackers or analytics of any kind. All your notes are stored c
 
 <b>Permissions</b>
 
-• show notifications, run foreground service
+* show notifications, run foreground service
 
 Used to display a notification if deleting images or importing backups takes time
 
-• prevent phone from sleeping, run at startup
+* prevent phone from sleeping, run at startup
 
 Used by the auto backup feature to ensure backups keep happening even if your phone is restarted
 

--- a/fastlane/metadata/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/android/fr-FR/full_description.txt
@@ -2,29 +2,29 @@ Notally est une application de prise de notes minimaliste avec un beau material 
 
 <b>Organisation</b>
 
-Créez des listes pour rester sur la bonne voie
-Épinglez des notes pour toujours les conserver en haut de l'écran
-Colorez et étiquetez vos notes pour une organisation rapide
-Archivez vos notes pour les garder à portée de main, mais hors de votre chemin
-Complétez vos notes avec des photos (JPG, PNG, WEBP)
-Créez des notes de texte enrichi avec prise en charge du gras, de l'italique, de la chasse fixe et du texte barré
-Ajoutez des liens cliquables à vos notes avec prise en charge des numéros de téléphone, des adresses mail et des URL web
+* Créez des listes pour rester sur la bonne voie
+* Épinglez des notes pour toujours les conserver en haut de l'écran
+* Colorez et étiquetez vos notes pour une organisation rapide
+* Archivez vos notes pour les garder à portée de main, mais hors de votre chemin
+* Complétez vos notes avec des photos (JPG, PNG, WEBP)
+* Créez des notes de texte enrichi avec prise en charge du gras, de l'italique, de la chasse fixe et du texte barré
+* Ajoutez des liens cliquables à vos notes avec prise en charge des numéros de téléphone, des adresses mail et des URL web
 
 <b>Exportez vos notes dans les formats suivants</b>
 
-• PDF
-• TXT
-• JSON
-• HTML
+* PDF
+* TXT
+* JSON
+* HTML
 
 <b>Avantages</b>
 
-• Mode sombre
-• Complètement gratuit
-• Taille du texte ajustable
-• Sauvegarde automatique et manuelle
-• Taille d'APK de 1,4 Mo (1,8 Mo décompressé)
-• Ajoutez vos notes et listes à votre écran d'accueil grâce aux widgets
+* Mode sombre
+* Complètement gratuit
+* Taille du texte ajustable
+* Sauvegarde automatique et manuelle
+* Taille d'APK de 1,4 Mo (1,8 Mo décompressé)
+* Ajoutez vos notes et listes à votre écran d'accueil grâce aux widgets
 
 <b>Vie privée</b>
 
@@ -32,11 +32,11 @@ Il n'y a pas de publicités, de traceurs ou d'analyses de toutes sortes. Toutes 
 
 <b>Permissions</b>
 
-• afficher des notifications, exécuter un service de premier plan
+* afficher des notifications, exécuter un service de premier plan
 
 Utilisé pour afficher une notification si la suppression d'images ou l'importation de sauvegarde prend un certain temps
 
-• empêcher le téléphone de passer en mode veille, s'exécuter au démarrage
+* empêcher le téléphone de passer en mode veille, s'exécuter au démarrage
 
 Utilisé par la fonction de sauvegarde automatique pour s'assurer que les sauvegardes continuent d'être enregistrées même après avoir redémarré votre appareil
 


### PR DESCRIPTION
This PR slightly improves formatting of the full descriptions, making it possible to render them as Markdown (supported e.g. at IzzyOnDroid) while keeping it compatible with places not supporting it (e.g. F-Droid.org, PlayStore). It also adds the German (de) locale with a short description – and the missing IzzyOnDroid badge to the Readme :wink: 