### PR TITLE
Log WebView load errors during PDF export

### DIFF
--- a/app/src/main/java/android/print/PostPDFGenerator.kt
+++ b/app/src/main/java/android/print/PostPDFGenerator.kt
@@ -2,9 +2,12 @@ package android.print
 
 import android.content.Context
 import android.os.ParcelFileDescriptor
+import android.util.Log
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import java.io.File
+
+private const val TAG = "PostPDFGenerator"
 
 /**
  * This class needs to be in android.print package to access the package private
@@ -20,6 +23,16 @@ object PostPDFGenerator {
             override fun onPageFinished(view: WebView?, url: String?) {
                 val adapter = webView.createPrintDocumentAdapter(file.nameWithoutExtension)
                 print(file, adapter, onResult)
+            }
+
+            @Deprecated("Deprecated in Java")
+            override fun onReceivedError(
+                view: WebView?,
+                errorCode: Int,
+                description: String?,
+                failingUrl: String?
+            ) {
+                Log.w(TAG, "WebView load error during PDF export: code=$errorCode, description=$description, url=$failingUrl")
             }
         }
     }


### PR DESCRIPTION
### What this does

Adds a single `onReceivedError(view, errorCode, description, failingUrl)` override to the `WebViewClient` used by `PostPDFGenerator.create(...)` in `app/src/main/java/android/print/PostPDFGenerator.kt`. It logs the error code, description and failing URL with `Log.w`. Adds a small file-level `private const val TAG = "PostPDFGenerator"`.

No behaviour change in the happy path. No new dependencies.

### Why

`onPageFinished` currently fires regardless of whether the load succeeded, so a print that ended up with missing assets ships through `createPrintDocumentAdapter(...)` and produces a half-rendered PDF with no logcat trace. This override makes the failure visible so future "exported PDF is missing parts" reports have something concrete to look at.

### Note on the signature

I used the deprecated 4-arg form rather than the API 23+ `(WebView, WebResourceRequest, WebResourceError)` overload on purpose. The app's `minSdk` is 21 and the framework dispatches the deprecated form on every API level when nothing else is overridden, so this single override actually fires for every user. Happy to switch to the new signature gated on `Build.VERSION.SDK_INT >= M` if you would prefer that style.