### PR TITLE
fix: prevent URLSpan(null) crash on unedited link tap

### DIFF
--- a/app/src/main/java/com/omgodse/notally/activities/TakeNote.kt
+++ b/app/src/main/java/com/omgodse/notally/activities/TakeNote.kt
@@ -94,22 +94,17 @@ class TakeNote : NotallyActivity(Type.NOTE) {
             MaterialAlertDialogBuilder(this)
                 .setItems(items) { dialog, which ->
                     if (which == 1) {
-                        val spanStart = binding.EnterBody.text?.getSpanStart(span)
-                        val spanEnd = binding.EnterBody.text?.getSpanEnd(span)
-
-                        ifBothNotNullAndInvalid(spanStart, spanEnd) { start, end ->
-                            val text = binding.EnterBody.text?.substring(start, end)
-                            if (text != null) {
-                                val link = getURLFrom(text)
-                                val uri = Uri.parse(link)
-
-                                val intent = Intent(Intent.ACTION_VIEW, uri)
-                                try {
-                                    startActivity(intent)
-                                } catch (exception: Exception) {
-                                    Toast.makeText(this, R.string.cant_open_link, Toast.LENGTH_LONG).show()
-                                }
+                        val spanUrl = span.URL
+                        if (spanUrl != null) {
+                            val uri = Uri.parse(spanUrl)
+                            val intent = Intent(Intent.ACTION_VIEW, uri)
+                            try {
+                                startActivity(intent)
+                            } catch (exception: Exception) {
+                                Toast.makeText(this, R.string.cant_open_link, Toast.LENGTH_LONG).show()
                             }
+                        } else {
+                            Toast.makeText(this, R.string.cant_open_link, Toast.LENGTH_LONG).show()
                         }
                     }
                 }.show()


### PR DESCRIPTION
## Summary
Fixes a crash when tapping an unedited link (one that was inserted but never had its URL set via the edit dialog).

## Problem
When a link is inserted from the toolbar without being edited, `URLSpan(null)` is created with a null URL. When tapped, the `LinkMovementMethod` callback in `TakeNote.kt` calls `Uri.parse(link)` where `link` is null, causing a crash.

## Fix
In the 'Open Link' handler, check if `span.URL` is null before attempting to parse and open it. If null, display the 'Can't open link' toast instead of crashing.

## Changes
- Modified `TakeNote.kt` to use `span.URL` directly and guard against null values

## Testing
- Insert a link via toolbar without editing it (so URL is null)
- Tap the link and verify the app doesn't crash
- Should show 'Can't open link' toast instead